### PR TITLE
error handling: less traceback, more cat-like

### DIFF
--- a/lolcat
+++ b/lolcat
@@ -13,8 +13,12 @@ import random
 import re
 import sys
 import time
+from signal import signal, SIGPIPE, SIG_DFL
 
 PY3 = sys.version_info >= (3,)
+
+# override default handler so no exceptions on SIGPIPE
+signal(SIGPIPE, SIG_DFL)
 
 # Reset terminal colors at exit
 def reset():
@@ -185,14 +189,18 @@ def run():
         args = ['-']
 
     for filename in args:
-        if filename == '-':
-            lolcat.cat(sys.stdin, options)
-        else:
-            try:
-                with open(filename, 'r') as handle:
+        try:
+            if filename == '-':
+                lolcat.cat(sys.stdin, options)
+            else:
+                with open(filename, 'r', errors='backslashreplace') as handle:
                     lolcat.cat(handle, options)
-            except IOError as error:
-                sys.stderr.write(str(error) + '\n')
+        except IOError as error:
+            sys.stderr.write(str(error) + '\n')
+        except KeyboardInterrupt:
+            sys.stderr.write('\n')
+            # exit 130 for terminated-by-ctrl-c, from http://tldp.org/LDP/abs/html/exitcodes.html
+            return 130
 
 if __name__ == '__main__':
     sys.exit(run())


### PR DESCRIPTION
This PR adds some more graceful (less traceback-filled) error handling and starts bringing `lolcat`'s error behavior closer to that of `cat` and similar utilities.  Added are handling of the KeyboardInterrupt exception, overriding of the default SIGPIPE handler to avoid BrokenPipeError exceptions, and avoiding of decoding exceptions by applying an encoding error handler to files when opened.

See [TESTS.md](https://github.com/arathkone/lolcat/blob/error-handling-1/TESTS.md) for some output comparisons.  (That file can be added to this PR upon request.)
