### PR TITLE
WINDOWS FIX: SIGPIPE and sys.out.print()

### DIFF
--- a/lolcat
+++ b/lolcat
@@ -15,12 +15,16 @@ import random
 import re
 import sys
 import time
-from signal import signal, SIGPIPE, SIG_DFL
+
+import platform
+
+if platform.system() != 'Windows':
+    from signal import signal, SIGPIPE, SIG_DFL
+
+    # override default handler so no exceptions on SIGPIPE
+    signal(SIGPIPE, SIG_DFL)
 
 PY3 = sys.version_info >= (3,)
-
-# override default handler so no exceptions on SIGPIPE
-signal(SIGPIPE, SIG_DFL)
 
 # Reset terminal colors at exit
 def reset():
@@ -161,7 +165,10 @@ class LolCat(object):
                 c if PY3 else c.encode(options.charset_py2, 'replace'),
             ]))
         if os.name == 'nt':
-            self.output.print()
+            if platform.system() == 'Windows':
+                self.output.prints()
+            else:
+                self.output.print()
 
 
 def detect_mode(term_hint='xterm-256color'):


### PR DESCRIPTION
invalid import of SIGPIPE for windows removed, Invalid use of sys.out.print() in windows changed to prints() method